### PR TITLE
add a dump command and tweak docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.bundle
+.git
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
-RUN apk -U add ca-certificates ruby ruby-bundler ruby-dev ruby-io-console ruby-builder ruby-irb ruby-rdoc ruby-json
+RUN apk -U add ca-certificates ruby ruby-bundler ruby-dev ruby-io-console ruby-irb ruby-rdoc ruby-json
 
 # Setup bundle user and directory
 RUN adduser -h /home/bundle -D bundle && \
@@ -9,13 +9,16 @@ RUN adduser -h /home/bundle -D bundle && \
 
 # Copy the bundle source to the image
 WORKDIR /home/bundle
-COPY . /home/bundle
+COPY Gemfile Gemfile.lock /home/bundle/
 
 # Install Git, run Bundler, and uninstall Git to recover space
 RUN apk add git && \
     su bundle -c 'bundle install --path .bundle' && \
     apk del git && \
     rm -f /var/cache/apk/*
+
+# Copy rest of code
+COPY . /home/bundle
 
 # Drop privileges
 USER bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'cog-rb'
+gem 'text-table'
+gem 'cog-rb', '~> 0.1.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cog-rb (0.1.5)
+    cog-rb (0.1.12)
+      rake (~> 11.2)
+    rake (11.2.2)
+    text-table (1.2.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  cog-rb
+  cog-rb (~> 0.1.9)
+  text-table
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/config.yaml
+++ b/config.yaml
@@ -2,13 +2,36 @@
 cog_bundle_version: 3
 name: pipewrench
 description: "Miscellaneous Cog pipeline utilities"
-version: "0.1.1"
+version: "0.2.0"
 docker:
   image: cogcmd/pipewrench
-  tag: "0.1.1"
+  tag: "0.2.0"
 commands:
   for:
     executable: /home/bundle/cog-command
     description: "Generator function for pipeline inputs"
     documentation: "pipewrench:for name in <arg1> ... <argN> - generate a list of objects with the value of arg1..N as the value of the field with the given name"
     rules: [ 'allow' ]
+  dump:
+    executable: /home/bundle/cog-command
+    description: "Return Cog pipeline options and input"
+    documentation: |
+      debug:dump [--env | -e] [--input | -i]
+
+      Options:
+        --env     Only return environment variables
+        --input   Only return STDIN content
+    options:
+      env:
+        type: bool
+        required: false
+        short_flag: e
+      input:
+        type: bool
+        required: false
+        short_flag: i
+    rules: [ 'allow' ]
+templates:
+  preformatted:
+    slack: '>>> ```{{{ body }}}```'
+    hipchat: '<pre>{{{ body }}}</pre>'

--- a/lib/cog_cmd/pipewrench/dump.rb
+++ b/lib/cog_cmd/pipewrench/dump.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+require 'cog/command'
+require 'text-table'
+
+class CogCmd::Pipewrench::Dump < Cog::Command
+  def run_command
+    body = ""
+    body += dump_environment if request.options['env'] || request.options == {}
+    body += dump_input if request.options['input'] || request.options == {}
+
+    response.template = "preformatted"
+    response['body'] = body
+  end
+
+  def dump_environment
+    table = Text::Table.new
+    table.head = [ 'Name', 'Value' ]
+    ENV.each { |k,v| table.rows << [ k, v ] }
+    return <<EOF
+Environment Variables:
+
+#{table.to_s}
+EOF
+  end
+
+  def dump_input
+    return <<EOF
+Pipeline Input:
+
+#{request.input.to_s}
+EOF
+  end
+end


### PR DESCRIPTION
- adds a simple command to dump ENV and/or STDIN
- tweak Dockerfile for faster builds by copying Gemfile.\* separately
- require cog-rb version 0.1.9 or newer specifically
